### PR TITLE
feat(mcp): expose MCP router in front of WireMock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,19 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+  mcp:
+    build: ./mcp
+    image: ${MCP_IMAGE:-isatis7/qapirag-mcp-mock:dev}
+    container_name: qapirag-mcp-mock
+    ports:
+      - "3000:3000"
+    environment:
+      - WIREMOCK_HOST=wiremock
+      - WIREMOCK_PORT=8080
+    depends_on:
+      - wiremock
+    restart: unless-stopped
+
 
 
 

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm ci --only=production || true
+COPY server.js ./
+EXPOSE 3000
+CMD ["node","server.js"]
+
+

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "qapirag-mcp-mock",
+  "version": "0.1.0",
+  "description": "MCP router in front of WireMock for QapiRag testing",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}
+
+

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+const WIREMOCK_HOST = process.env.WIREMOCK_HOST || 'wiremock';
+const WIREMOCK_PORT = process.env.WIREMOCK_PORT || '8080';
+const WIREMOCK_BASE = `http://${WIREMOCK_HOST}:${WIREMOCK_PORT}`;
+
+function forwardHeaders(req) {
+  const headers = {};
+  if (req.headers['authorization']) headers['Authorization'] = req.headers['authorization'];
+  headers['Accept'] = 'application/json';
+  return headers;
+}
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'UP' });
+});
+
+app.post('/mcp/get_issue', async (req, res) => {
+  const key = req.body && req.body.issueKey;
+  if (!key) return res.status(400).json({ error: 'missing issueKey' });
+  try {
+    const url = `${WIREMOCK_BASE}/rest/api/3/issue/${encodeURIComponent(key)}`;
+    const resp = await fetch(url, { headers: forwardHeaders(req) });
+    const contentType = resp.headers.get('content-type') || '';
+    const body = contentType.includes('application/json') ? await resp.json() : await resp.text();
+    res.status(resp.status).send(body);
+  } catch (e) {
+    console.error(e);
+    res.status(502).json({ error: 'bad gateway', detail: e.message });
+  }
+});
+
+app.post('/mcp/search_issues', async (req, res) => {
+  const jql = req.body && req.body.jql;
+  if (!jql) return res.status(400).json({ error: 'missing jql' });
+  try {
+    const url = `${WIREMOCK_BASE}/rest/api/3/search?jql=${encodeURIComponent(jql)}`;
+    const resp = await fetch(url, { headers: forwardHeaders(req) });
+    const contentType = resp.headers.get('content-type') || '';
+    const body = contentType.includes('application/json') ? await resp.json() : await resp.text();
+    res.status(resp.status).send(body);
+  } catch (e) {
+    console.error(e);
+    res.status(502).json({ error: 'bad gateway', detail: e.message });
+  }
+});
+
+app.post('/mcp/get_changelog', async (req, res) => {
+  const key = req.body && req.body.issueKey;
+  if (!key) return res.status(400).json({ error: 'missing issueKey' });
+  try {
+    const url = `${WIREMOCK_BASE}/rest/api/3/issue/${encodeURIComponent(key)}?expand=changelog`;
+    const resp = await fetch(url, { headers: forwardHeaders(req) });
+    const contentType = resp.headers.get('content-type') || '';
+    const body = contentType.includes('application/json') ? await resp.json() : await resp.text();
+    res.status(resp.status).send(body);
+  } catch (e) {
+    console.error(e);
+    res.status(502).json({ error: 'bad gateway', detail: e.message });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`MCP router listening on ${PORT}, forwarding to ${WIREMOCK_BASE}`);
+});
+

--- a/scripts/test-mcp.sh
+++ b/scripts/test-mcp.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# script to start wiremock + mcp and test MCP get_issue
+set -euo pipefail
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$here"
+
+echo "Pull images and start services (wiremock + mcp)"
+docker compose pull wiremock || true
+docker compose up -d --no-deps wiremock mcp
+
+# wait for wiremock
+for i in $(seq 1 30); do
+  if curl -sS http://127.0.0.1:8092/health 2>/dev/null | grep -q '"status":"UP"'; then
+	echo "WireMock ready"; break
+  fi
+  echo "waiting wiremock... $i"; sleep 2
+done
+
+# wait for mcp
+for i in $(seq 1 30); do
+  if curl -sS http://127.0.0.1:3000/health 2>/dev/null | grep -q '"status":"UP"'; then
+	echo "MCP ready"; break
+  fi
+  echo "waiting mcp... $i"; sleep 2
+done
+
+# call MCP get_issue
+resp=$(curl -sS -H "Content-Type: application/json" -d '{"issueKey":"QAPI-123"}' http://127.0.0.1:3000/mcp/get_issue)
+if echo "$resp" | grep -q '"key".*"QAPI-123"'; then
+  echo "MCP get_issue returned expected fixture"
+  exit 0
+else
+  echo "MCP get_issue did not return expected fixture:" >&2
+  echo "$resp" >&2
+  exit 2
+fi
+
+


### PR DESCRIPTION
Exposes MCP endpoints get_issue, search_issues, get_changelog and adds MCP service to docker-compose. Includes test script scripts/test-mcp.sh.